### PR TITLE
Mark Hadolint findings as static

### DIFF
--- a/dojo/tools/hadolint/parser.py
+++ b/dojo/tools/hadolint/parser.py
@@ -50,6 +50,8 @@ def get_item(vulnerability, test):
         mitigation="No mitigation provided",
         false_p=False,
         duplicate=False,
+        static_finding=True,
+        dynamic_finding=False,
         out_of_scope=False,
         mitigated=None,
         impact="No impact provided")


### PR DESCRIPTION
Fix issue #4730.

Issue description: Hadolint parser has no specific configuration regarding static/dynamic status of its findings. So it uses the default status, i.e. "dynamic", whereas Hadolint is a SAST, not a DAST. For consistency, Hadolint findings should be "static", not "dynamic". This wrong "dynamic" value has impacts on deduplication.